### PR TITLE
doc: remove the retention-days option from 3.0

### DIFF
--- a/docs/source/sctool/partials/sctool_backup.yaml
+++ b/docs/source/sctool/partials/sctool_backup.yaml
@@ -100,11 +100,6 @@ options:
   usage: |
     The `number of backups` to store, once this number is reached, the next backup which comes in from this destination will initiate a purge of the oldest backup.
     Can be used simultaneously with '--retention-days' flag.
-- name: retention-days
-  default_value: "0"
-  usage: |
-    The `number of days` for which backup is stored, the next backup will initiate a purge of all expired backups.
-    Can be used simultaneously with '--retention' flag.
 - name: retry-wait
   default_value: 10m
   usage: |


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/13617
The option is only introduced in version 3.1 and should be removed from the docs for version 3.0.
